### PR TITLE
Request to add one relevant paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ We will actively maintain this repository by incorporating new research as it em
     - **[NeurIPS 2023]** ProlificDreamer: High-Fidelity and Diverse Text-to-3D Generation with Variational Score Distillation. [[Paper]](https://arxiv.org/pdf/2305.16213) [[Code]](https://github.com/thu-ml/prolificdreamer)
     - **[NeurIPS 2023]** Diff-Instruct: A Universal Approach for Transferring Knowledge From Pre-trained Diffusion Models. [[Paper]](https://arxiv.org/pdf/2305.18455) [[Code]](https://github.com/pkulwj1994/diff_instruct)
     - **[CVPR 2024]** 3D Paintbrush: Local Stylization of 3D Shapes with Cascaded Score Distillation. [[Paper]](https://arxiv.org/pdf/2311.09571) [[Code]](https://github.com/threedle/3d-paintbrush)
+    - **[CVPR 2025]** MoFlow: One-Step Flow Matching for Human Trajectory Forecasting via Implicit Maximum Likelihood Estimation based Distillation [[Paper]](https://arxiv.org/pdf/2503.09950) [[Code]](https://github.com/felix-yuxiang/MoFlow)
 
 ### System
 


### PR DESCRIPTION
Hi, I came across the Efficient-Diffusion-Model-Survey and truly appreciate the effort in curating such a valuable resource for the community.

I’d like to request the addition of our paper "MoFlow: One-Step Flow Matching for Human Trajectory Forecasting via Implicit Maximum Likelihood Estimation based Distillation" to the survey to help increase its visibility and contribute to the growing body of research on efficient diffusion models. 

Please let me know if you need any further details. I’d be happy to provide additional information. Looking forward to your thoughts!